### PR TITLE
updating docs for JWEDecrypter::decryptUsingKey usage

### DIFF
--- a/components/encrypted-tokens-jwe/jwe-loading.md
+++ b/components/encrypted-tokens-jwe/jwe-loading.md
@@ -70,7 +70,7 @@ $token = 'eyJhbGciOiJBMjU2S1ciLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwiemlwIjoiREVGIn0.9R
 $jwe = $serializerManager->unserialize($token);
 
 // We decrypt the token. This method does NOT check the header.
-$jwe = $jweDecrypter->decryptUsingKey($jwe, $jwk);
+$success = $jweDecrypter->decryptUsingKey($jwe, $jwk, 0);
 ```
 
 OK so if not exception is thrown, then your token is loaded and the payload correctly decrypted.


### PR DESCRIPTION
The call to decryptUsingKey needed an additional parameter and the return value represents success/failure not the decrypted payload.