### PR TITLE
Typo fix claim => claims

### DIFF
--- a/the-easy-way/easy.md
+++ b/the-easy-way/easy.md
@@ -75,7 +75,7 @@ $jwt = Load::jws($token) // We want to load and verify the token in the variable
 ;
 ```
 
-If everything is ok, the variable `$jwt` contains a `Jose\Easy\JWT` object. This object has 2 properties: `header` and `claim` containing the loaded values.
+If everything is ok, the variable `$jwt` contains a `Jose\Easy\JWT` object. This object has 2 properties: `header` and `claims` containing the loaded values.
 
 ```php
 $jwt->claims->all(); // All claims (array)


### PR DESCRIPTION
Single character typo fix.

This fixes the issue where it previously suggested you use `$jwt->claim` instead of `$jwt->claims`.