### PR TITLE
Fix docs for `jose.jku_factory.request_factory`

### DIFF
--- a/the-symfony-bundle/key-and-key-set-management/key-set-management-jwkset.md
+++ b/the-symfony-bundle/key-and-key-set-management/key-set-management-jwkset.md
@@ -55,7 +55,7 @@ jose:
     jku_factory:
         enabled: true
         client: 'httplug.client.acme' # The Httplug client
-        request_factory: 'httplug.message_factory' # In general, you will use the same message factory as the one used by Httplug
+        request_factory: 'httplug.psr17_request_factory' # In general, you will use the same request factory as the one used by HTTPlug
 ```
 
 **Important recommendations:**


### PR DESCRIPTION
If you pass `httplug.message_factory`, as it was stated in the docs, you get:
![grafik](https://github.com/user-attachments/assets/d11cc9c7-ad14-4d95-a491-0a318c54695a)
