### PR TITLE
Fix the installation instructions for the Symfony bundle

### DIFF
--- a/the-symfony-bundle/symfony-bundle.md
+++ b/the-symfony-bundle/symfony-bundle.md
@@ -42,7 +42,7 @@ The bundle supports Symfony 7.0 and Symfony 8.0.
 The bundle is automatically detected and installed when using Symfony Flex:
 
 ```bash
-composer require web-token/jwt-framework
+composer require web-token/jwt-bundle
 ```
 
 {% hint style="info" %}


### PR DESCRIPTION
Updated the composer package requirement from 'jwt-framework' to 'jwt-bundle'. Installing the development mono-repo is not recommended.